### PR TITLE
fix: update newsletter link to buttondown

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -29,9 +29,9 @@
     <a href="https://www.instagram.com/legesher/">
         <img src="https://img.shields.io/badge/-Connect-black?style=flat-square&logo=instagram&logoColor=7ed2e7"
             alt="Follow on Instagram"></a>
-    <a href="https://mailchi.mp/083d8b2e0e12/legesher-landing-page">
-        <img src="https://img.shields.io/badge/-Subscribe-black?style=flat-square&logo=mailchimp&logoColor=7ed2e7"
-            alt="Subscribe on Mailchimp"></a>    
+    <a href="https://buttondown.com/legesher">
+        <img src="https://img.shields.io/badge/-Subscribe-black?style=flat-square&logo=minutemailer&logoColor=7ed2e7"
+            alt="Subscribe on Buttondown"></a>    
 </p>
 <!-- SOCIAL MEDIA -->
 


### PR DESCRIPTION
This pull request updates the newsletter subscription link in the `profile/README.md` file. The Mailchimp subscription link and badge have been replaced with a Buttondown link and corresponding badge.

- Social Media/Newsletter:
  * Updated the newsletter subscription link from Mailchimp to Buttondown and changed the badge logo from Mailchimp to Minutemailer in `profile/README.md`.