### PR TITLE
docs: add bug report issue template

### DIFF
--- a/.github/bug_report.md
+++ b/.github/bug_report.md
@@ -1,0 +1,65 @@
+---
+name: "🐛 Bug report"
+about: Report a bug to help us improve Legesher
+title: "[Bug]: <short summary of the issue>"
+labels: "bug"
+assignees: ''
+---
+
+<!--
+Thank you for taking the time to report a bug! Please fill out as much of this form as possible.
+Thorough, clear documentation helps us resolve issues faster.
+Fields marked with * are required.
+-->
+
+## 🐞 Describe the Bug *
+_A clear and concise description of what the bug is. What did you expect to happen? What actually happened?_
+
+---
+
+## 🔁 Steps to Reproduce *
+_Help us reproduce the issue by providing step-by-step instructions:_
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+---
+
+## 💻 Environment *
+_Complete as much as possible. If unsure, leave blank or write "unknown"._
+- OS: [e.g. macOS 14.5, Windows 11, Ubuntu 22.04]
+- Browser: [e.g. Chrome 124, Safari 17]
+- Device: [e.g. MacBook Pro, iPhone 14]
+- App Version/Commit: [e.g. v1.2.3, commit hash]
+
+---
+
+## 📸 Screenshots / Videos
+_If applicable, add screenshots or a screen recording to help explain your problem._
+
+---
+
+## 📝 Logs & Error Messages
+_If you see any error messages, copy and paste them here. You can also drag and drop log files or use [GitHub Gist](https://gist.github.com/) for longer logs._
+
+---
+
+## 💡 Possible Solution / Additional Notes
+_Any thoughts as to potential solutions, workarounds, or ideas for further investigation? Please include links to any research or related issues._
+
+---
+
+## 🔗 Related Issues
+_If this bug is related to another issue or pull request, please link it here (e.g. #123)._
+
+---
+
+## 🧩 Additional Context
+_Add any other context about the problem here. For example, network conditions, custom configurations, or anything else you think might be relevant._
+
+---
+
+<!--
+Thank you for helping us make Legesher better!
+-->


### PR DESCRIPTION
This pull request adds a new GitHub issue template for reporting bugs. The template provides a structured format to help users submit thorough and actionable bug reports, making it easier for maintainers to understand and resolve issues.

Issue reporting improvements:

* Added a `.github/bug_report.md` issue template with clearly defined sections for bug description, reproduction steps, environment details, screenshots, logs, possible solutions, related issues, and additional context.