### PR TITLE
Add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: legesher


### PR DESCRIPTION
## Summary
- Add FUNDING.yml to enable the "Sponsor" button on Legesher repositories
- Links to the Legesher GitHub Sponsors page

## Test plan
- [ ] Verify the Sponsor button appears on the repository page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)